### PR TITLE
fix: add pvcName from harddrive to nocodb values.yaml

### DIFF
--- a/molecules/cluster-resources/config/externals/nocodb/values.yaml
+++ b/molecules/cluster-resources/config/externals/nocodb/values.yaml
@@ -92,7 +92,7 @@ storage:
   enabled: true
   size: 3Gi
   storageClassName: "openebs-hostpath"
-  pvcName: "nocodb"
+  pvcName: "pvc-homelab-app-data-nocodb"
 
 postgresql:
   enabled: false


### PR DESCRIPTION
closes #89 