### PR TITLE
Feat: Expose keycloak using `ingress-nginx`

### DIFF
--- a/molecules/cluster-resources/config/externals/keycloak/ingress.values.tftpl
+++ b/molecules/cluster-resources/config/externals/keycloak/ingress.values.tftpl
@@ -1,0 +1,20 @@
+flags:
+  rewrite: false
+
+service:
+  name: keycloak-http
+  port:
+    number: 80
+
+annotations:
+  hajimari.io/enable: "true"
+  hajimari.io/appName: "idp"
+
+ingress:
+  subdomain: idp
+  routePath: /
+
+hosts:
+%{ for host in hosts ~}
+- name: ${host}
+%{ endfor ~}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced external access configuration for Keycloak through an Ingress controller, enhancing connectivity and routing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->