### PR TITLE
Fix: Deploy ingress controller daemonset only on pi node

### DIFF
--- a/molecules/cluster-resources/config/externals/ingress-nginx/values.yaml
+++ b/molecules/cluster-resources/config/externals/ingress-nginx/values.yaml
@@ -17,6 +17,8 @@ commonLabels: {}
 
 controller:
   name: controller
+  nodeSelector:
+    kubernetes.io/hostname: pi
   enableAnnotationValidations: false
   image:
     ## Keep false as default for now!


### PR DESCRIPTION
pi5 is failing ingress-nginx - since I am using only pi as ingress, no need to have the controller deployed to both nodes anyway for now - using nodeSelector to only deploy to pi