### PR TITLE
Feat: Add DrawIO helm chart

### DIFF
--- a/molecules/cluster-resources/config/externals/drawio/values.yaml
+++ b/molecules/cluster-resources/config/externals/drawio/values.yaml
@@ -1,0 +1,41 @@
+image:
+  repository: jgraph/drawio
+  tag: 24.6.2@sha256:535f762e49551b2f32d540d8376be1e9422fc9d71eaeebf6012f60f88ae136f6
+  pullPolicy: IfNotPresent
+
+securityContext:
+  container:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+
+service:
+  main:
+    ports:
+      main:
+        port: 10214
+        targetPort: 8080
+
+workload:
+  main:
+    podSpec:
+      containers:
+        main:
+          probes:
+            liveness:
+              type: http
+              path: /
+            readiness:
+              type: http
+              path: /
+            startup:
+              type: http
+              path: /
+          env: {}
+      nodeSelector:
+        kubernetes.io/hostname: pi
+
+portal:
+  open:
+    enabled: true

--- a/molecules/cluster-resources/config/ingresses/drawio.tftpl
+++ b/molecules/cluster-resources/config/ingresses/drawio.tftpl
@@ -1,0 +1,16 @@
+flags:
+  rewrite: false
+
+service:
+  name: drawio
+  port:
+    number: 10214
+
+ingress:
+  subdomain: drawio
+  routePath: /
+
+hosts:
+%{ for host in hosts ~}
+- name: ${host}
+%{ endfor ~}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configuration settings for the Draw.io container, including image details, security settings, service ports, and workload specifications.
  - Added ingress setup for the Draw.io service with subdomain routing and host details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->