### PR TITLE
Fix: Move Draw IO ingress to config folder

### DIFF
--- a/molecules/cluster-resources/config/externals/drawio/ingress.values.tftpl
+++ b/molecules/cluster-resources/config/externals/drawio/ingress.values.tftpl
@@ -1,0 +1,20 @@
+flags:
+  rewrite: false
+
+service:
+  name: drawio
+  port:
+    number: 10214
+
+annotations:
+  hajimari.io/enable: "true"
+  hajimari.io/appName: "Draw IO"
+
+ingress:
+  subdomain: drawio
+  routePath: /
+
+hosts:
+%{ for host in hosts ~}
+- name: ${host}
+%{ endfor ~}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configuration settings for the Draw IO service, including port details, service annotations, and subdomain/route path settings for Ingress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->