### PR TITLE
Feat: Install nvidia GPU operator using terraform

### DIFF
--- a/molecules/cluster-resources/mrsauravsahu.tfvars
+++ b/molecules/cluster-resources/mrsauravsahu.tfvars
@@ -73,6 +73,12 @@ externals = [
      version = "12.6.1"
      namespace = "homelab"
     },
+    {
+      name = "gpu-operator",
+      repo = "https://helm.ngc.nvidia.com/nvidia",
+      version = "v25.3.1",
+      namespace = "gpu-operator"
+    },
     // TODO: nextcloud fails due to slow startup, need to figure this out
     #  {
     #    name = "nextcloud"


### PR DESCRIPTION
## Impact Surface by monotools/semver-yeasy
- cluster-resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying the GPU Operator via an external Helm chart, enabling GPU management capabilities within the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

![image](https://github.com/user-attachments/assets/9206e123-fa92-4f28-951e-59e2ca4531c5)
