### PR TITLE
Chore: Add gpu-operator values.yaml

### DIFF
--- a/molecules/cluster-resources/config/externals/gpu-operator/values.yaml
+++ b/molecules/cluster-resources/config/externals/gpu-operator/values.yaml
@@ -1,0 +1,2 @@
+driver:
+  enabled: false


### PR DESCRIPTION
Add values.yaml to not install NVidia driver for Nvidia GPU operator as I installed in manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable toggle to enable or disable the GPU driver in the GPU Operator configuration. Disabled by default for safer rollouts, it provides clearer control for clusters that don’t require a driver and simplifies future enablement. No behavior changes occur unless administrators explicitly turn it on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->